### PR TITLE
Update Saxon to a more recent version to remove saxon9-dom.jar dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ project("grobid-core") {
         compile "com.google.guava:guava:19.0"
         compile "net.arnx:jsonic:1.3.10"
         compile "org.apache.pdfbox:pdfbox:1.8.9"
-        compile "net.sourceforge.saxon:saxon:9.1.0.8"
+        compile "net.sf.saxon:Saxon-HE:9.6.0-9"
         compile "xom:xom:1.2.5"
         compile "com.fasterxml.jackson.core:jackson-core:2.9.1"
         compile "com.fasterxml.jackson.core:jackson-databind:2.9.1"


### PR DESCRIPTION
This removes the downstream dependency on saxon9-dom.jar - see:

https://stackoverflow.com/a/15441957/9098739