### PR TITLE
Assign sanitizedEmails to authorEmailAssigner

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -3161,7 +3161,7 @@ public class BiblioItem {
         List<String> sanitizedEmails = emailSanitizer.splitAndClean(emailles);
 
         if (sanitizedEmails != null) {
-            authorEmailAssigner.assign(fullAuthors, emailles);
+            authorEmailAssigner.assign(fullAuthors, sanitizedEmails);
         }
     }
 


### PR DESCRIPTION
Current code sanitizes the emails but then assigns the unsanitized version to authorEmailAssigner.
